### PR TITLE
Korrektur von related-Links, Spezifizierung von Matching-Relationen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ URI: TODO (Weiterleitung über w3id.org einrichten)
 
 Werteliste für Schulfächer in der deutschen Bildungslandschaft, gepflegt von der [OER-Metadatengruppe der DINI-AG-KIM](https://wiki.dnb.de/x/IQ30B).
 
-Die Werteliste ist ein SKOS-Vokabular und enthält Relationen (`skos:relatedMatch`) zu der [EAF-Sachgebietssystematik](http://agmud.de/sachgebietssystematik/) der [AG-MUD](agmud.de) und der [OpenEduHub-Fächersystematik](http://w3id.org/openeduhub/vocabs/discipline) (Hinweis: Die Sachgebietssystematik der AG-MUD liegt nicht selbst in SKOS vor, sondern wurde basierend auf der XLSX-Datei konvertiert: https://github.com/openeduhub/oeh-metadata-eaf-sachgebietssystematiken).
+Die Werteliste ist ein SKOS-Vokabular und enthält Relationen (`skos:closeMatch`) zu der [EAF-Sachgebietssystematik](http://agmud.de/sachgebietssystematik/) der [AG-MUD](agmud.de) und der [OpenEduHub-Fächersystematik](http://w3id.org/openeduhub/vocabs/discipline) (Hinweis: Die Sachgebietssystematik der AG-MUD liegt nicht selbst in SKOS vor, sondern wurde basierend auf der XLSX-Datei konvertiert: https://github.com/openeduhub/oeh-metadata-eaf-sachgebietssystematiken).
 
 **Mitarbeit und Kontakt** über [Issues](https://github.com/dini-ag-kim/hcrt/issues/), die [Mailingliste der OER-Metadatengruppe](https://lists.dnb.de/mailman/listinfo/dini-ag-kim-oer) oder die [Mailingliste der Curricula-Gruppe](https://lists.dnb.de/mailman/listinfo/dini-ag-kim-curricula).

--- a/schulfaecher.ttl
+++ b/schulfaecher.ttl
@@ -149,7 +149,7 @@
     skos:prefLabel "MINT"@de ;
     skos:altLabel "Chemie, Physik, Biologie"@de ;
     skos:altLabel "Naturwissenschaften"@de ;
-    skos:related <s1003>, <s1023>, <s1002>, <s1008>, <s1014> ;
+    skos:related <s1001>, <s1002>, <s1013>, <s1017>, <s1022> ;
     skos:topConceptOf <> .
 
 <s1020> a skos:Concept ;

--- a/schulfaecher.ttl
+++ b/schulfaecher.ttl
@@ -24,20 +24,20 @@
 
 <s1000> a skos:Concept ;
     skos:prefLabel "Alt-Griechisch"@de ;
-    skos:relatedMatch eafsys:20003 ;
-    skos:relatedMatch oeh:20003 ;
+    skos:closeMatch eafsys:20003 ;
+    skos:closeMatch oeh:20003 ;
     skos:topConceptOf <> .
 
 <s1001> a skos:Concept ;
     skos:prefLabel "Biologie"@de ;
-    skos:relatedMatch eafsys:080 ;
-    skos:relatedMatch oeh:080 ;
+    skos:closeMatch eafsys:080 ;
+    skos:closeMatch oeh:080 ;
     skos:topConceptOf <> .
 
 <s1002> a skos:Concept ;
     skos:prefLabel "Chemie"@de ;
-    skos:relatedMatch eafsys:100 ;
-    skos:relatedMatch oeh:100 ;
+    skos:closeMatch eafsys:100 ;
+    skos:closeMatch oeh:100 ;
     skos:topConceptOf <> .
 
 <s1003> a skos:Concept ;
@@ -46,102 +46,102 @@
 
 <s1004> a skos:Concept ;
     skos:prefLabel "Darstellendes Spiel"@de ;
-    skos:relatedMatch eafsys:12002 ;
-    skos:relatedMatch oeh:12002 ;
+    skos:closeMatch eafsys:12002 ;
+    skos:closeMatch oeh:12002 ;
     skos:topConceptOf <> .
 
 <s1005> a skos:Concept ;
     skos:prefLabel "Deutsch"@de ;
     skos:altLabel "Muttersprache"@de ;
-    skos:relatedMatch eafsys:120 ;
-    skos:relatedMatch oeh:120 ;
+    skos:closeMatch eafsys:120 ;
+    skos:closeMatch oeh:120 ;
     skos:topConceptOf <> .
 
 <s1006> a skos:Concept ;
     skos:prefLabel "Deutsch als Zweitsprache"@de ;
     skos:altLabel "DaZ"@de ;
-    skos:relatedMatch eafsys:12005 ;
-    skos:relatedMatch oeh:12005 ;
+    skos:closeMatch eafsys:12005 ;
+    skos:closeMatch oeh:12005 ;
     skos:topConceptOf <> .
 
 <s1007> a skos:Concept ;
     skos:prefLabel "Englisch"@de ;
-    skos:relatedMatch eafsys:20001 ;
-    skos:relatedMatch oeh:20001 ;
+    skos:closeMatch eafsys:20001 ;
+    skos:closeMatch oeh:20001 ;
     skos:topConceptOf <> .
 
 <s1008> a skos:Concept ;
     skos:prefLabel "Ethik"@de ;
-    skos:relatedMatch eafsys:160 ;
-    skos:relatedMatch oeh:160 ;
+    skos:closeMatch eafsys:160 ;
+    skos:closeMatch oeh:160 ;
     skos:topConceptOf <> .
 
 <s1009> a skos:Concept ;
     skos:prefLabel "Französisch"@de ;
-    skos:relatedMatch eafsys:20002 ;
-    skos:relatedMatch oeh:20002 ;
+    skos:closeMatch eafsys:20002 ;
+    skos:closeMatch oeh:20002 ;
     skos:topConceptOf <> .
 
 <s1010> a skos:Concept ;
     skos:prefLabel "Geografie"@de ;
     skos:altLabel "Erdkunde"@de ;
     skos:altLabel "Geographie"@de ;
-    skos:relatedMatch eafsys:220 ;
-    skos:relatedMatch oeh:220 ;
+    skos:closeMatch eafsys:220 ;
+    skos:closeMatch oeh:220 ;
     skos:topConceptOf <> .
 
 <s1011> a skos:Concept ;
     skos:prefLabel "Geschichte"@de ;
-    skos:relatedMatch eafsys:20002 ;
-    skos:relatedMatch oeh:20002 ;
+    skos:closeMatch eafsys:20002 ;
+    skos:closeMatch oeh:20002 ;
     skos:topConceptOf <> .
 
 <s1012> a skos:Concept ;
     skos:prefLabel "Gesundheit"@de ;
     skos:altLabel "Gesundheitserziehung"@de ;
-    skos:relatedMatch eafsys:260 ;
-    skos:relatedMatch oeh:260 ;
+    skos:closeMatch eafsys:260 ;
+    skos:closeMatch oeh:260 ;
     skos:topConceptOf <> .
 
 <s1013> a skos:Concept ;
     skos:prefLabel "Informatik"@de ;
     skos:altLabel "Informations- und Kommunikationstechnologie"@de ;
-    skos:relatedMatch eafsys:320 ;
-    skos:relatedMatch oeh:320 ;
+    skos:closeMatch eafsys:320 ;
+    skos:closeMatch oeh:320 ;
     skos:topConceptOf <> .
 
 <s1014> a skos:Concept ;
     skos:prefLabel "Italienisch"@de ;
-    skos:relatedMatch eafsys:20004 ;
-    skos:relatedMatch oeh:20004 ;
+    skos:closeMatch eafsys:20004 ;
+    skos:closeMatch oeh:20004 ;
     skos:topConceptOf <> .
 
 <s1015> a skos:Concept ;
     skos:prefLabel "Kunst"@de ;
     skos:altLabel "Kunsterziehung"@de ;
-    skos:relatedMatch eafsys:060 ;
-    skos:relatedMatch oeh:060 ;
+    skos:closeMatch eafsys:060 ;
+    skos:closeMatch oeh:060 ;
     skos:topConceptOf <> .
 
 <s1016> a skos:Concept ;
     skos:prefLabel "Latein"@de ;
-    skos:relatedMatch eafsys:20005 ;
-    skos:relatedMatch oeh:20005 ;
+    skos:closeMatch eafsys:20005 ;
+    skos:closeMatch oeh:20005 ;
     skos:topConceptOf <> .
 
 <s1017> a skos:Concept ;
     skos:prefLabel "Mathematik"@de ;
     skos:altLabel "Mathe"@de ;
-    skos:relatedMatch eafsys:380 ;
-    skos:relatedMatch oeh:380 ;
+    skos:closeMatch eafsys:380 ;
+    skos:closeMatch oeh:380 ;
     skos:topConceptOf <> .
 
 <s1018> a skos:Concept ;
     skos:prefLabel "Mediendidaktik"@de ;
     skos:altLabel "Medienerziehung"@de ;
     skos:definition "Mediendidaktik befasst sich mit der Erziehung durch Medien"@de ;
-    skos:relatedMatch eafsys:400 ;
-    skos:relatedMatch oeh:400 ;
+    skos:closeMatch eafsys:400 ;
+    skos:closeMatch oeh:400 ;
     skos:editorialNote "Auf EAF-Sachgebietssystematik 'Medienpädagogik'(400) gemapped."@de ;
     skos:topConceptOf <> .
 
@@ -154,91 +154,91 @@
 
 <s1020> a skos:Concept ;
     skos:prefLabel "Musik"@de ;
-    skos:relatedMatch eafsys:420 ;
-    skos:relatedMatch oeh:420 ;
+    skos:closeMatch eafsys:420 ;
+    skos:closeMatch oeh:420 ;
     skos:topConceptOf <> .
 
 <s1021> a skos:Concept ;
     skos:prefLabel "Philosophie"@de ;
-    skos:relatedMatch eafsys:450 ;
-    skos:relatedMatch oeh:450 ;
+    skos:closeMatch eafsys:450 ;
+    skos:closeMatch oeh:450 ;
     skos:topConceptOf <> .
 
 <s1022> a skos:Concept ;
     skos:prefLabel "Physik"@de ;
-    skos:relatedMatch eafsys:460 ;
-    skos:relatedMatch oeh:460 ;
+    skos:closeMatch eafsys:460 ;
+    skos:closeMatch oeh:460 ;
     skos:topConceptOf <> .
 
 <s1023> a skos:Concept ;
     skos:prefLabel "Politik"@de ;
     skos:altLabel "Politische Bildung"@de ;
-    skos:relatedMatch eafsys:480 ;
-    skos:relatedMatch oeh:480 ;
+    skos:closeMatch eafsys:480 ;
+    skos:closeMatch oeh:480 ;
     skos:topConceptOf <> .
 
 <s1024> a skos:Concept ;
     skos:prefLabel "Religionslehre (evangelische)"@de ;
     skos:altLabel "Evangelischer Religionsunterricht"@de ;
-    skos:relatedMatch eafsys:520 ;
-    skos:relatedMatch oeh:520 ;
+    skos:closeMatch eafsys:520 ;
+    skos:closeMatch oeh:520 ;
     skos:topConceptOf <> .
 
 <s1025> a skos:Concept ;
     skos:prefLabel "Religionslehre (islamisch)"@de ;
     skos:altLabel "Islamischer Religionsunterricht"@de ;
-    skos:relatedMatch eafsys:520 ;
-    skos:relatedMatch oeh:520 ;
+    skos:closeMatch eafsys:520 ;
+    skos:closeMatch oeh:520 ;
     skos:topConceptOf <> .
 
 <s1026> a skos:Concept ;
     skos:prefLabel "Religionslehre (katholische)"@de ;
     skos:altLabel "Katholischer Religionsunterricht"@de ;
-    skos:relatedMatch eafsys:520 ;
-    skos:relatedMatch oeh:520 ;
+    skos:closeMatch eafsys:520 ;
+    skos:closeMatch oeh:520 ;
     skos:topConceptOf <> .
 
 <s1027> a skos:Concept ;
     skos:prefLabel "Russisch"@de ;
-    skos:relatedMatch eafsys:20006 ;
-    skos:relatedMatch oeh:20006 ;
+    skos:closeMatch eafsys:20006 ;
+    skos:closeMatch oeh:20006 ;
     skos:topConceptOf <> .
 
 <s1028> a skos:Concept ;
     skos:prefLabel "Sachunterricht"@de ;
     skos:altLabel "Heimatunterricht"@de ;
-    skos:relatedMatch eafsys:28010 ;
-    skos:relatedMatch oeh:28010 ;
+    skos:closeMatch eafsys:28010 ;
+    skos:closeMatch oeh:28010 ;
     skos:topConceptOf <> .
 
 <s1029> a skos:Concept ;
     skos:prefLabel "Sexualerziehung"@de ;
-    skos:relatedMatch eafsys:560 ;
-    skos:relatedMatch oeh:560 ;
+    skos:closeMatch eafsys:560 ;
+    skos:closeMatch oeh:560 ;
     skos:topConceptOf <> .
 
 <s1030> a skos:Concept ;
     skos:prefLabel "Spanisch"@de ;
-    skos:relatedMatch eafsys:20007 ;
-    skos:relatedMatch oeh:20007 ;
+    skos:closeMatch eafsys:20007 ;
+    skos:closeMatch oeh:20007 ;
     skos:topConceptOf <> .
 
 <s1031> a skos:Concept ;
     skos:prefLabel "Sport"@de ;
     skos:altLabel "Sportunterricht"@de ;
-    skos:relatedMatch eafsys:600 ;
-    skos:relatedMatch oeh:600 ;
+    skos:closeMatch eafsys:600 ;
+    skos:closeMatch oeh:600 ;
     skos:topConceptOf <> .
 
 <s1032> a skos:Concept ;
     skos:prefLabel "Türkisch"@de ;
-    skos:relatedMatch eafsys:20008 ;
-    skos:relatedMatch oeh:20008 ;
+    skos:closeMatch eafsys:20008 ;
+    skos:closeMatch oeh:20008 ;
     skos:topConceptOf <> .
 
 <s1033> a skos:Concept ;
     skos:prefLabel "Wirtschaftskunde"@de ;
-    skos:relatedMatch eafsys:700 ;
-    skos:relatedMatch oeh:700 ;
+    skos:closeMatch eafsys:700 ;
+    skos:closeMatch oeh:700 ;
     skos:topConceptOf <> .
 

--- a/schulfaecher.ttl
+++ b/schulfaecher.ttl
@@ -150,8 +150,6 @@
     skos:altLabel "Chemie, Physik, Biologie"@de ;
     skos:altLabel "Naturwissenschaften"@de ;
     skos:related <s1003>, <s1023>, <s1002>, <s1008>, <s1014> ;
-    skos:relatedMatch oeh:100, oeh:080, oeh:460, oeh:380, oeh:320 ;
-    skos:relatedMatch eafsys:100, eafsys:080, eafsys:460, eafsys:380, eafsys:320 ;
     skos:topConceptOf <> .
 
 <s1020> a skos:Concept ;


### PR DESCRIPTION
Dieser PR 

1. ändert die Matching-Relationen auf EAF Sachgebietssystematik und OpenEduhub Fächersystematik von `relatedMatch` zu `closeMatch`. (Tatsächlich könnten wir in Zukunft bei einigen noch eine weitere Spezifizierung hin zu `exactMatch` diskutieren.)
2. Repariert die Vokabular-internen `related` Links von MINT zu Chemie, Physik, Informatik, Biologie und Mathematik
3. entfernt die externen Matching-Relationen für MINT, weil diese schon vermittelt existieren (MINT hat `related`-Relation zu Fächern, die wiederum `closeMatch`-Links auf andere Systematiken haben). 